### PR TITLE
SQL code block implementation and small bug fix to structureoutline

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 				"scopeName": "source.sm-structure",
 				"path": "./syntaxes/sm-structure.json",
 				"embeddedLanguages": {
-					"markup.raw.sm-structure": "sql"
+					"meta.embedded.block.sql": "sql"
 				}
 			}
 		],

--- a/src/structureOutline.ts
+++ b/src/structureOutline.ts
@@ -37,7 +37,7 @@ export class StructureOutlineProvider implements vscode.DocumentSymbolProvider {
         this.viewPattern = /(?<![a-z_])view\s+(?<viewName>[a-zA-Z_]+)\s*[a-zA-Z_\s\',]*;/gi;
 
         //Regex for instance default entities
-        this.instance = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)(?<groupType>table_defaults|index_defaults)[\s]+(?<AttribString>[(),'`<>-\s\[=\]_.\d$+/*A-Za-z]*);/gi;
+       this.instance = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)(?<groupType>table_defaults|index_defaults)[\s]+(?<AttribString>[(),'`<>-\s\[=\]_.\d$+/*A-Za-z]*);/gi;
         //Regext for instance attributes
        this.instancettrib = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)(?<groupType>oracle_location|sqlserver_location|\bsqlserver_collation\b|sqlserver_collation_case_sensitive|sqlserver_use_nvarchar)\s*(?<Value>['\d_A-Za-z]+)[^\s;]/gi;
 
@@ -46,7 +46,7 @@ export class StructureOutlineProvider implements vscode.DocumentSymbolProvider {
 
                 //Field or table attribute regex syntaxes.
                 this.collectAttrib = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)\bon\b\s+(?<collectTable>[a-zA-Z_]+)\s+(\busing\b)\s+(?<collectField>[a-zA-Z_]+)[^\s\n]/gi;
-                this.linksTo = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)(?<linkType>\blinks_to\b|\blinks_to parent\b)\s+(?<linkedTable>[a-zA-Z_]+)\s[.]\s(?<linkedField>[a-zA-Z_]+)/gi;
+                this.linksTo = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)(?<linkType>\blinks_to\b|\blinks_to parent\b)\s+(?<linkedTable>[a-zA-Z_]+)\s*[.]\s*(?<linkedField>[a-zA-Z_]+)/gi;
                 this.alias = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)\balias\s+(?<alias>[a-zA-Z_]+)\b/gi;
                 this.datatype = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)datatype\s*(?<datatype>[a-zA-Z_]+)/gi;
                 this.usedFor = /(?<!{(?:(?!})[\s\S\r])*?)(?<!{\*(?:(?!\*})[\s\S\r])*?)\bused_for\s+(?<usedforName>[a-zA-Z_]+)\b/gi;
@@ -124,7 +124,7 @@ export class StructureOutlineProvider implements vscode.DocumentSymbolProvider {
 
                         let range = new vscode.Range(document.positionAt(selectionStart), document.positionAt(selectionEnd));
 
-                        let attribsymbol = new vscode.DocumentSymbol(attribute, attribmatches.groups.linkType.toLocaleLowerCase(), vscode.SymbolKind.Interface, range, range);
+                        let attribsymbol = new vscode.DocumentSymbol(attribute, attribmatches.groups.linkType.toLocaleLowerCase().capitalize(), vscode.SymbolKind.Interface, range, range);
                         fieldsymbol.children.push(attribsymbol);
                         
                     }

--- a/syntaxes/sm-structure.json
+++ b/syntaxes/sm-structure.json
@@ -39,12 +39,37 @@
             "match": "(?i)\\b(alias|allowed_characters|as|blob|case_sensitive|choose_type|default|delete_audit|descending|false_word|false|format|identities|insert_audit|library|links_to|lower_limit|modify_audit|nobuffer|noidentities|noindex|on|on_table|oracle_location|oracle_specific|parent|parent_table|phrase_type|physical_name|prompt|prompt_description|prompt_type|rdb_location|rdb_specific|read_only|rename_table|routine|silent|sqlserver_collation|sqlserver_collation_case_sensitive|sqlserver_use_nvarchar|sqlserver_location|sqlserver_specific|tableset|true_word|true|unique|upper_limit|used_for|valid|using|major|minor)\\b"
         },
 
+        "fenced-code-block": {
+            "patterns":[
+               
+                {"include": "#fenced-code-block-sql"}
+        
+            ]
+        },
+        "fenced-code-block-sql": {
+            "name": "markup.raw.vgl-structure",
+            "begin": "(?i)\\b(select_clause|(oracle|sqlserver|rdb)_specific_select)\\b",
+            "end": ";",
+            "beginCaptures": {
+                "0": { "name": "sql.sm-structure.open" }
+            },
+            "endCaptures": {
+                "0": { "name": "sql.sm-structure.close" }
+            },
+            "contentName": "meta.embedded.block.sql",
+            "patterns":[
+                {
+                    "include": "source.sql"
+                }
+            ]
+			
+        },
+
         "literal": {
             "patterns": [
                 { "include": "#literal-string" },
                 { "include": "#literal-numeric" },
-                { "include": "#literal-special" },
-                { "include": "#literal-sql" }
+                { "include": "#literal-special" }
             ]
         },
         "literal-string": {
@@ -59,19 +84,6 @@
             "name": "constant.language.sm-structure",
             "match": "(?i)\\bnull\\b"
         },
-        "literal-sql": {
-            "name": "markup.raw.sm-structure",
-            "begin": "(?i)\\b(select_clause|(oracle|sqlserver|rdb)_specific_select)\\b",
-            "end": ";",
-            "beginCaptures": {
-                "0": { "name": "sql.sm-structure.open" }
-            },
-            "endCaptures": {
-                "0": { "name": "sql.sm-structure.close" }
-            }
-
-        },
-
         "comment": {
             "patterns": [{ "include": "#comment-block" }]
         },

--- a/syntaxes/sm-structure.json
+++ b/syntaxes/sm-structure.json
@@ -5,7 +5,8 @@
     "patterns": [
         { "include": "#keyword" },
         { "include": "#comment" },
-        { "include": "#literal" }
+        { "include": "#literal" },
+        { "include": "#fenced-code-block"}
     ],
 
     "repository": {
@@ -47,7 +48,7 @@
             ]
         },
         "fenced-code-block-sql": {
-            "name": "markup.raw.vgl-structure",
+            "name": "markup.raw.sm-structure",
             "begin": "(?i)\\b(select_clause|(oracle|sqlserver|rdb)_specific_select)\\b",
             "end": ";",
             "beginCaptures": {


### PR DESCRIPTION
I found a small issue with the RegEx string used for "Link_to" items that was preventing them to be found when parsed.


Updated the Structure syntax to use some OOTB highlighting for SQL.   This will also allow SQL specific snippets to work here.   
![sql block_snippet](https://user-images.githubusercontent.com/60077909/107653614-710bab00-6c47-11eb-9210-234bb3b5e71f.PNG)
